### PR TITLE
Legger til støtte for azure/entra-token for å kunne hente meldekort og historiske meldekort i meldekortregister

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -30,6 +30,7 @@ spec:
     {{/each}}
   secureLogs:
     enabled: true
+
   env:
     - name: MELDEKORTSERVICE_URL
       value: 'https://{{ meldekortserviceHost }}/meldekortservice/api'

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -30,7 +30,6 @@ spec:
     {{/each}}
   secureLogs:
     enabled: true
-
   env:
     - name: MELDEKORTSERVICE_URL
       value: 'https://{{ meldekortserviceHost }}/meldekortservice/api'


### PR DESCRIPTION
Ifbm migrering av meldekort for bruker som får vedtak som ikke skrives til Arena.

Støtter azure/endra-token i `/sendterapporteringsperioder` og `/rapporteringsperioder`. 
Legger til ident-header i begge endepunkt. `/sendterapporteringsperioder` har også fått en ny header for antallMeldeperioder som ved null settes til 10.